### PR TITLE
Make rendering updates work (Linux at least)

### DIFF
--- a/core/QVTKQuickItem.cxx
+++ b/core/QVTKQuickItem.cxx
@@ -12,6 +12,7 @@
 #include <QOpenGLShaderProgram>
 #include <QQuickWindow>
 #include <QThread>
+#include <QSGSimpleRectNode>
 
 #include "QVTKInteractor.h"
 #include "QVTKInteractorAdapter.h"
@@ -29,7 +30,8 @@
 
 #include <iostream>
 
-QVTKQuickItem::QVTKQuickItem()
+QVTKQuickItem::QVTKQuickItem(QQuickItem* parent)
+:QQuickItem(parent)
 {
   setFlag(ItemHasContents);
   setAcceptHoverEvents(true);
@@ -293,6 +295,17 @@ void QVTKQuickItem::init()
 void QVTKQuickItem::prepareForRender()
 {
 }
+  
+QSGNode* QVTKQuickItem::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*)
+{
+  QSGSimpleRectNode *n = static_cast<QSGSimpleRectNode *>(oldNode);
+  if (!n) {
+    n = new QSGSimpleRectNode();
+  }
+  n->markDirty(QSGNode::DirtyForceUpdate);
+  return n;
+}
+
 
 void QVTKQuickItem::paint()
 {

--- a/core/QVTKQuickItem.h
+++ b/core/QVTKQuickItem.h
@@ -32,7 +32,7 @@ class OVCORE_EXPORT QVTKQuickItem : public QQuickItem
 {
   Q_OBJECT
 public:
-  QVTKQuickItem();
+  QVTKQuickItem(QQuickItem* parent = 0);
 
   // Description:
   // destructor
@@ -89,6 +89,8 @@ protected:
   virtual void hoverEnterEvent(QHoverEvent* e);
   virtual void hoverLeaveEvent(QHoverEvent* e);
   virtual void hoverMoveEvent(QHoverEvent* e);
+
+  virtual QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* updatePaintNodeData);
 
   QMutex m_viewLock;
 


### PR DESCRIPTION
Dear Jeff,

I tried OpenView on Ubuntu 12.04 and did not get proper updates to the graphs without the following patch (only got one frame and then the next when the whole scene needed an update).

I just started using QML and I assume you had proper updates on your machine, so I am not sure how much this patch is needed. However, from the documentation at http://qt-project.org/doc/qt-5.0/qtquick/qquickitem.html I was surprised how it could have worked without the updatePaintNode method.

Regards,
Daniel
