### PR TITLE
Early initialization and fix errors from vtkOpenGLExtensionManager

### DIFF
--- a/core/QVTKQuickItem.cxx
+++ b/core/QVTKQuickItem.cxx
@@ -12,6 +12,7 @@
 #include <QOpenGLShaderProgram>
 #include <QQuickWindow>
 #include <QThread>
+#include <QSGSimpleRectNode>
 
 #include "QVTKInteractor.h"
 #include "QVTKInteractorAdapter.h"
@@ -29,7 +30,8 @@
 
 #include <iostream>
 
-QVTKQuickItem::QVTKQuickItem()
+QVTKQuickItem::QVTKQuickItem(QQuickItem* parent)
+:QQuickItem(parent)
 {
   setFlag(ItemHasContents);
   setAcceptHoverEvents(true);
@@ -293,6 +295,17 @@ void QVTKQuickItem::init()
 void QVTKQuickItem::prepareForRender()
 {
 }
+  
+QSGNode* QVTKQuickItem::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*)
+{
+  QSGSimpleRectNode *n = static_cast<QSGSimpleRectNode *>(oldNode);
+  if (!n) {
+    n = new QSGSimpleRectNode();
+  }
+  n->markDirty(QSGNode::DirtyForceUpdate);
+  return n;
+}
+
 
 void QVTKQuickItem::paint()
 {

--- a/core/QVTKQuickItem.cxx
+++ b/core/QVTKQuickItem.cxx
@@ -297,6 +297,10 @@ void QVTKQuickItem::init()
 void QVTKQuickItem::prepareForRender()
 {
 }
+
+void QVTKQuickItem::cleanupAfterRender()
+{
+}
   
 QSGNode* QVTKQuickItem::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*)
 {
@@ -362,6 +366,8 @@ void QVTKQuickItem::paint()
 
   // Disable alpha test for QML
   glDisable(GL_ALPHA_TEST);
+
+  cleanupAfterRender();
 
   this->m_viewLock.unlock();
 }

--- a/core/QVTKQuickItem.cxx
+++ b/core/QVTKQuickItem.cxx
@@ -74,9 +74,11 @@ void QVTKQuickItem::SetRenderWindow(vtkGenericOpenGLRenderWindow* win)
     //m_connect->Connect(m_win, vtkCommand::WindowMakeCurrentEvent, this, SLOT(MakeCurrent()));
     //m_connect->Connect(m_win, vtkCommand::EndEvent, this, SLOT(End()));
     //m_connect->Connect(m_win, vtkCommand::WindowFrameEvent, this, SLOT(Update()));
-    m_connect->Connect(m_win, vtkCommand::WindowIsCurrentEvent, this, SLOT(IsCurrent(vtkObject*, unsigned long, void*, void*)));
-    m_connect->Connect(m_win, vtkCommand::WindowIsDirectEvent, this, SLOT(IsDirect(vtkObject*, unsigned long, void*, void*)));
-    m_connect->Connect(m_win, vtkCommand::WindowSupportsOpenGLEvent, this, SLOT(SupportsOpenGL(vtkObject*, unsigned long, void*, void*)));
+    // Qt::DirectConnection in order to execute callback immediately.
+    // This avoids an error when vtkTexture attempts to query driver features and it is unable to determine "IsCurrent"
+    m_connect->Connect(m_win, vtkCommand::WindowIsCurrentEvent, this, SLOT(IsCurrent(vtkObject*, unsigned long, void*, void*)), NULL, 0.0, Qt::DirectConnection);
+    m_connect->Connect(m_win, vtkCommand::WindowIsDirectEvent, this, SLOT(IsDirect(vtkObject*, unsigned long, void*, void*)), NULL, 0.0, Qt::DirectConnection);
+    m_connect->Connect(m_win, vtkCommand::WindowSupportsOpenGLEvent, this, SLOT(SupportsOpenGL(vtkObject*, unsigned long, void*, void*)), NULL, 0.0, Qt::DirectConnection);
     }
 }
 

--- a/core/QVTKQuickItem.h
+++ b/core/QVTKQuickItem.h
@@ -74,6 +74,7 @@ protected:
 
   virtual void init();
   virtual void prepareForRender();
+  virtual void cleanupAfterRender();
 
   // handle item key events
   virtual void keyPressEvent(QKeyEvent* e);

--- a/core/QVTKQuickItem.h
+++ b/core/QVTKQuickItem.h
@@ -32,7 +32,7 @@ class OVCORE_EXPORT QVTKQuickItem : public QQuickItem
 {
   Q_OBJECT
 public:
-  QVTKQuickItem();
+  QVTKQuickItem(QQuickItem* parent = 0);
 
   // Description:
   // destructor
@@ -89,6 +89,8 @@ protected:
   virtual void hoverEnterEvent(QHoverEvent* e);
   virtual void hoverLeaveEvent(QHoverEvent* e);
   virtual void hoverMoveEvent(QHoverEvent* e);
+
+  virtual QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* updatePaintNodeData);
 
   QMutex m_viewLock;
 

--- a/core/QVTKQuickItem.h
+++ b/core/QVTKQuickItem.h
@@ -101,6 +101,8 @@ private:
   vtkSmartPointer<QVTKInteractor> m_interactor;
   QVTKInteractorAdapter* m_interactorAdapter;
   vtkSmartPointer<vtkEventQtSlotConnect> m_connect;
+
+  bool m_InitCalledOnce;
 };
 
 #endif


### PR DESCRIPTION
I worked a bit more on a ![QML prototype for MITK](https://github.com/maleike/MITK/tree/personal/maleike/qml-openview-rendering/Examples/QuickRender) and made three minor changes/improvements to QVTKQuickItem which I hope you find useful and are able to integrate:
- vtkOpenGLExtensionManager errors of type "Attempting to load GL_VERSION_2_0, which is not supported." could be removed by a Qt::DirectConnection to IsCurrent()
- introduced a counter-part to prepareForRender() called cleanupAfterRender()
- the initialization that is being done once in the paint() method has been moved to the c'tor with the intention that sub-classes may access the VTK render window in their c'tor already. This makes using the class much easier in the MITK application mentioned above

Behavior the OpenView application did not change as much as I can see.
